### PR TITLE
Change the log level of closing log to info from debug

### DIFF
--- a/loggestd/src/log_file.rs
+++ b/loggestd/src/log_file.rs
@@ -46,7 +46,7 @@ impl LogFile {
 
         let archived_path = archive_directory.join(filename.file_name().unwrap());
 
-        debug!("{} -> {}", filename.display(), archived_path.display());
+        info!("Closed {}", filename.display());
         rename(&filename, &archived_path)
     }
 


### PR DESCRIPTION
Change log message to "Closed {filename}"

This is needed so that tools that parse these logs can know the approximate start and end timestamp of each log file